### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "wiredep": "^2.2.2"
   },
   "cordovaPlugins": [
-    "org.apache.cordova.device",
-    "org.apache.cordova.console",
-    "com.ionic.keyboard",
-    "org.apache.cordova.splashscreen",
-    "org.apache.cordova.statusbar"
+    "cordova-plugin-device",
+    "cordova-plugin-console",
+    "ionic-plugin-keyboard",
+    "cordova-plugin-splashscreen",
+    "cordova-plugin-statusbar"
   ],
   "cordovaPlatforms": []
 }


### PR DESCRIPTION
Change the package names to install them properly with the ionic state restore command.

I've noticed when trying to install and run this app the cordova plugins weren't installed because of wrong (maybe outdated) package names.